### PR TITLE
Max error message

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,12 @@
                 <img src="assets/error-icon.svg" class="error-icon"><span class="error-message"> Must be less than Max</span>
               </div>
             </div>
-
             <div class="form-elements style-range-inputs">
               <label for="max-range-input">Max Range</label>
               <input type="text" name="range" id="max-range-input">
+              <div class="max-below-min-error" hidden>
+                <img src="assets/error-icon.svg" class="error-icon"><span class="error-message"> Must be greater than Min</span>
+              </div>
             </div>
           <button class="update-btn" name="range">UPDATE</button>
         </div>

--- a/main.js
+++ b/main.js
@@ -85,12 +85,14 @@ guess2.addEventListener('keyup', function() {
 minRangeInput.addEventListener('keyup', function() {
   validateNumber(minRangeInput);
   minAboveMaxError();
+  maxBelowMinError();
 
 });
 
 maxRangeInput.addEventListener('keyup', function() {
   validateNumber(maxRangeInput);
   maxBelowMinError();
+  minAboveMaxError();
 });
 
 
@@ -162,7 +164,7 @@ function minAboveMaxError() {
     minErrorElem.removeAttribute('hidden');
   }
   if (newMinRange < newMaxRange) {
-    minErrorElem.style.borderColor = 'gray';
+    minRangeInput.style.borderColor = 'gray';
     minErrorElem.setAttribute('hidden', true);
   }
 }
@@ -177,7 +179,7 @@ function maxBelowMinError() {
     maxErrorElem.removeAttribute('hidden');
   }
   if (newMaxRange > newMinRange || maxRange <= minRange) {
-    maxErrorElem.removeAttribute('border-color');
+    maxRangeInput.style.borderColor = 'gray';
     maxErrorElem.setAttribute('hidden', true);
   }
 }

--- a/main.js
+++ b/main.js
@@ -23,6 +23,7 @@ var name2 = document.querySelector('.scoreboard-name2');
 var min = document.querySelector('.min-output');
 var max = document.querySelector('.max-output');
 var minErrorElem = document.querySelector('.min-above-max-error');
+var maxErrorElem = document.querySelector('.max-below-min-error');
 var guessErrorElem1 = document.querySelector('.guess-outside-range-error-1');
 var guessErrorElem2 = document.querySelector('.guess-outside-range-error-2');
 
@@ -89,6 +90,7 @@ minRangeInput.addEventListener('keyup', function() {
 
 maxRangeInput.addEventListener('keyup', function() {
   validateNumber(maxRangeInput);
+  maxBelowMinError();
 });
 
 
@@ -155,13 +157,28 @@ function validateNumber(num) {
 function minAboveMaxError() {
   var newMinRange = parseInt(minRangeInput.value);
   var newMaxRange = parseInt(maxRangeInput.value);
-  if (newMinRange >= newMaxRange || minRange > maxRange) {
+  if (newMinRange >= newMaxRange || minRange >= maxRange) {
     minRangeInput.style.borderColor = '#DD1972';
     minErrorElem.removeAttribute('hidden');
   }
   if (newMinRange < newMaxRange) {
     minErrorElem.style.borderColor = 'gray';
     minErrorElem.setAttribute('hidden', true);
+  }
+}
+
+//find and replace 'gray' with actual gray hex code
+
+function maxBelowMinError() {
+  var newMinRange = parseInt(minRangeInput.value);
+  var newMaxRange = parseInt(maxRangeInput.value);
+  if (newMaxRange <= newMinRange || maxRange <= minRange) {
+    maxRangeInput.style.borderColor = "#DD1972"; 
+    maxErrorElem.removeAttribute('hidden');
+  }
+  if (newMaxRange > newMinRange || maxRange <= minRange) {
+    maxErrorElem.removeAttribute('border-color');
+    maxErrorElem.setAttribute('hidden', true);
   }
 }
 


### PR DESCRIPTION
I realized that the pink range borders weren't removed when necessary because I was targeting the hidden div rather than the input element. 

Also added max/min error functions to both min and max input event listeners to allow the warnings to update in real time. We can change this if you don't like it! I just thought it was better than leaving the error there.